### PR TITLE
Fix broken hash comparison and crashes

### DIFF
--- a/threaded-libcurl/DownloadManager.moon
+++ b/threaded-libcurl/DownloadManager.moon
@@ -209,6 +209,9 @@ class DownloadManager
 	-- just make them instance methods than trying to juggle the DM init.
 	-- Also make them fat arrow functions for calling consistency.
 	checkFileSHA1: ( filename, expected ) =>
+		filenameType, expectedType = type(filename), type(expected)
+		assert filenameType=="string" and expectedType=="string", msgs.checkMissingArgs\format filenameType, expectedType
+
 		result = DM.getFileSHA1 filename
 		if nil == result
 			return nil, "Could not open file #{filename}."
@@ -218,6 +221,9 @@ class DownloadManager
 			return false, "Hash mismatch. Got #{result}, expected #{expected}."
 
 	checkStringSHA1: ( string, expected ) =>
+		stringType, expectedType = type(string), type(expected)
+		assert stringType=="string" and expectedType=="string", msgs.checkMissingArgs\format stringType, expectedType
+
 		result = DM.getStringSHA1 string
 		if result == expected\lower!
 			return true

--- a/threaded-libcurl/DownloadManager.moon
+++ b/threaded-libcurl/DownloadManager.moon
@@ -90,7 +90,8 @@ class DownloadManager
 
 	msgs = {
 		notInitialized: "#{@__name} not initialized.",
-		addMissingArgs: "Arguments #1 (url) and #2 (outfile) must not be nil, got url=%s, outfile=%s.",
+		addMissingArgs: "Required arguments #1 (url) or #2 (outfile) had the wrong type. Expected string, got '%s' and '%s'.",
+		checkMissingArgs: "Required arguments #1 (filename/string) and #2 (expected) or the wrong type. Expected string, got '%s' and '%s'.",
 		outNoFullPath: "Argument #2 (outfile) must contain a full path (relative paths not supported), got %s.",
 		outNoFile: "Argument #2 (outfile) must contain a full path with file name, got %s."
 	}
@@ -130,8 +131,8 @@ class DownloadManager
 	addDownload: ( url, outfile, sha1 ) =>
 		return nil, msgs.notInitialized unless DM
 
-		unless url and outfile
-			return nil, msgs.addMissingArgs\format tostring(url), tostring(outfile)
+		urlType, outfileType = type(url), type(outfile)
+		assert urlType=="string" and outfileType=="string", msgs.addMissingArgs\format urlType, outfileType
 
 		-- expand leading ~ ourselves.
 		if homeDir = os.getenv "HOME"

--- a/threaded-libcurl/DownloadManager.moon
+++ b/threaded-libcurl/DownloadManager.moon
@@ -212,7 +212,7 @@ class DownloadManager
 		filenameType, expectedType = type(filename), type(expected)
 		assert filenameType=="string" and expectedType=="string", msgs.checkMissingArgs\format filenameType, expectedType
 
-		result = DM.getFileSHA1 filename
+		result = ffi.string DM.getFileSHA1 filename
 		if nil == result
 			return nil, "Could not open file #{filename}."
 		if result == expected\lower!
@@ -224,7 +224,7 @@ class DownloadManager
 		stringType, expectedType = type(string), type(expected)
 		assert stringType=="string" and expectedType=="string", msgs.checkMissingArgs\format stringType, expectedType
 
-		result = DM.getStringSHA1 string
+		result = ffi.string DM.getStringSHA1 string
 		if result == expected\lower!
 			return true
 		else


### PR DESCRIPTION
This fixes 
- \checkFileSHA1() and \checkStringSHA1() always returning false (hash mismatch) due to a missing ctype -> string conversion.
- crashes due to missing/bad arguments 
