### PR TITLE
add DependencyControl support

### DIFF
--- a/bad-mutex/BadMutex.moon
+++ b/bad-mutex/BadMutex.moon
@@ -10,7 +10,8 @@ libVer = BM.version!
 if libVer < BMVersion or math.floor(libVer/65536%256) > math.floor(BMVersion/65536%256)
 	error "Library version mismatch. Wanted #{BMVersion}, got #{libVer}."
 
-return {
+local BadMutex
+BadMutex = {
 	lock: ->
 		BM.lock!
 
@@ -21,5 +22,17 @@ return {
 		BM.unlock!
 
 	version: 0x000102
+	attachDepctrl: (DependencyControl) ->
+		BadMutex.version = DependencyControl{
+		    name: "BadMutex",
+		    version: BadMutex.version,
+		    description: "A global mutex.",
+		    author: "torque",
+		    url: "https://github.com/torque/ffi-experiments",
+		    moduleName: "BM.BadMutex",
+		    feed: "https://raw.githubusercontent.com/torque/ffi-experiments/master/DependencyControl.json",
+		}
 	:loadedLibraryPath
 }
+
+return BadMutex

--- a/precise-timer/PreciseTimer.moon
+++ b/precise-timer/PreciseTimer.moon
@@ -16,6 +16,16 @@ if libVer < PTVersion or math.floor(libVer/65536%256) > math.floor(PTVersion/655
 class PreciseTimer
 	@version = 0x000104
 	@version_string = "0.1.4"
+	@attachDepctrl = (DependencyControl) ->
+		@version = DependencyControl{
+		    name: "#{@__name}",
+		    version: @version_string,
+		    description: "Measure times down to the nanosecond. Except not really.",
+		    author: "torque",
+		    url: "https://github.com/torque/ffi-experiments",
+		    moduleName: "PT.#{@__name}",
+		    feed: "https://raw.githubusercontent.com/torque/ffi-experiments/master/DependencyControl.json",
+		}
 	:loadedLibraryPath
 
 	freeTimer = ( timer ) ->

--- a/requireffi/requireffi.moon
+++ b/requireffi/requireffi.moon
@@ -52,5 +52,19 @@ requireffi = ( name ) =>
 
 	return tryLoad name, packagePaths namespace, libraryName
 
-return setmetatable { :version }, { __call: requireffi }
+local versionRecord
+versionRecord = {
+	:version,
+	attachDepctrl: (DependencyControl) ->
+		versionRecord.version = DependencyControl{
+		    name: "requireffi",
+		    version: version,
+		    description: "FFI.load wrapper for loading C modules.",
+		    author: "torque",
+		    url: "https://github.com/torque/ffi-experiments",
+		    moduleName: "requireffi.requireffi",
+		    feed: "https://raw.githubusercontent.com/torque/ffi-experiments/master/DependencyControl.json",
+		}
+}
+return setmetatable versionRecord, { __call: requireffi }
 

--- a/threaded-libcurl/DownloadManager.moon
+++ b/threaded-libcurl/DownloadManager.moon
@@ -81,6 +81,16 @@ strdup = ffi.os == "Windows" and ffi.C._strdup or ffi.C.strdup
 class DownloadManager
 	@version = 0x000201
 	@version_string = "0.2.1"
+	@attachDepctrl = (DependencyControl) ->
+		@version = DependencyControl{
+		    name: "#{@__name}",
+		    version: @version_string,
+		    description: "Download things with libcurl without blocking Lua.",
+		    author: "torque",
+		    url: "https://github.com/torque/ffi-experiments",
+		    moduleName: "DM.#{@__name}",
+		    feed: "https://raw.githubusercontent.com/torque/ffi-experiments/master/DependencyControl.json",
+		}
 	:loadedLibraryPath
 
 	msgs = {


### PR DESCRIPTION
Adds a function to BM, DM, PT and requireffi modules that creates a DependencyControl version record. Since these modules are DepCtrl dependencies, this function/method can and will be called only after DependencyControl has finished loading. 

This change is required to make DependencyControl capable of self-update, which requires required modules to also be updatable when new version are required.
