### PR TITLE
Use `build_by_default` instead of run_target workaround

### DIFF
--- a/bad-mutex/meson.build
+++ b/bad-mutex/meson.build
@@ -13,6 +13,7 @@ if host_machine.system() != 'windows'
     bad_mutex_lua = custom_target('BadMutexLua',
         output: ['BadMutex.lua'],
         input: [bad_mutex_moon],
-        command: [lua_builder, '@INPUT@', '@OUTPUT@']
+        command: [lua_builder, '@INPUT@', '@OUTPUT@'],
+        build_by_default: true
     )
 endif

--- a/download-manager/meson.build
+++ b/download-manager/meson.build
@@ -15,6 +15,7 @@ if host_machine.system() != 'windows'
     download_manager_lua = custom_target('DownloadManagerLua',
         output: ['DownloadManager.lua'],
         input: [download_manager_moon],
-        command: [lua_builder, '@INPUT@', '@OUTPUT@']
+        command: [lua_builder, '@INPUT@', '@OUTPUT@'],
+        build_by_default: true
     )
 endif

--- a/meson.build
+++ b/meson.build
@@ -48,17 +48,3 @@ subdir('bad-mutex')
 subdir('precise-timer')
 subdir('download-manager')
 subdir('requireffi')
-
-if host_machine.system() != 'windows'
-    # meson is garbage and run_target appears to be the only way to
-    # actually add a new compilation target to ninja.
-    run_target('lua',
-        command: find_program('true'),
-        depends: [
-            bad_mutex_lua,
-            download_manager_lua,
-            precise_timer_lua,
-            requireffi_lua
-        ]
-    )
-endif

--- a/precise-timer/meson.build
+++ b/precise-timer/meson.build
@@ -13,6 +13,7 @@ if host_machine.system() != 'windows'
     precise_timer_lua = custom_target('PreciseTimerLua',
         output: ['PreciseTimer.lua'],
         input: [precise_timer_moon],
-        command: [lua_builder, '@INPUT@', '@OUTPUT@']
+        command: [lua_builder, '@INPUT@', '@OUTPUT@'],
+        build_by_default: true
     )
 endif

--- a/requireffi/meson.build
+++ b/requireffi/meson.build
@@ -6,6 +6,7 @@ if host_machine.system() != 'windows'
     requireffi_lua = custom_target('requireffiLua',
         output: ['requireffi.lua'],
         input: [requireffi_moon],
-        command: [lua_builder, '@INPUT@', '@OUTPUT@']
+        command: [lua_builder, '@INPUT@', '@OUTPUT@'],
+        build_by_default: true
     )
 endif


### PR DESCRIPTION
The commands are run when I `ninja -v`, but the build currently doesn't work for me because moonscript is broken on Arch atm (see also #10).