### PR TITLE
Fix build errors inside flatpak environment

### DIFF
--- a/BuildLua.sh
+++ b/BuildLua.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -z $2 ]; then
 	echo "Usage: $0 input_file output_file [input2 output2 ...]"

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ $(DownloadManager): LDFLAGS += -pthread
 endif
 $(DownloadManager): $(DM_OBJECTS)
 	@printf "\e[1;32m LINK\e[m $@\n"
-	@$(CXX) $(LDFLAGS) -o $@ $^
+	@$(CXX) $(LDFLAGS) -o $@ $^ -lcurl
 
 $(PreciseTimer): $(PT_OBJECTS)
 	@printf "\e[1;32m LINK\e[m $@\n"


### PR DESCRIPTION
When building this inside a flatpak-builder environment, the build fails, if not using bash and not explicitly linking curl